### PR TITLE
New partner default check variant ABAP_CLOUD_DEVELOPMENT_PARTNER

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Software components are imported into the system by using the [`Clone` strategy]
 - Clone software components relevant for the add-on build
 
 #### [ATC](https://www.project-piper.io/pipelines/abapEnvironment/stages/test/#atc)
-- Check software components to be assembled as part of the add-on build via ABAP Test Cockpit (Check Variant: ABAP_CLOUD_DEVELOPMENT_DEFAULT)
+- Check software components to be assembled as part of the add-on build via ABAP Test Cockpit (Check Variant: ABAP_CLOUD_DEVELOPMENT_PARTNER)
 - ATC results in checkstyle format are displayed using the [Warnings Next Generation Plugin](https://www.jenkins.io/doc/pipeline/steps/warnings-ng/#warnings-next-generation-plugin)
 - [Quality gate configurations](https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#quality-gate-configuration) to block priority error and warning ATC findings are defined (build result = FAILURE), pipeline execution is aborted in this case with error
 - A [Quality gate configuration](https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#quality-gate-configuration) to report ATC findings of any priority is defined (build result = UNSTABLE)
@@ -109,7 +109,7 @@ Definition of addon product version/software component versions bundle to be ass
 Please refer to the documentation on [Add-on descriptor file](https://www.project-piper.io/scenarios/abapEnvironmentAddons/#add-on-descriptor-file) for more information.
 
 ### [atcConfig.yml](atcConfig.yml)
-Configuration of software components checked via ATC, check variant `ABAP_CLOUD_DEVELOPMENT_DEFAULT` is used for check runs.<br>
+Configuration of software components checked via ATC, check variant `ABAP_CLOUD_DEVELOPMENT_PARTNER` is used for check runs.<br>
 Please include all software components configured in [addon.yml](addon.yml) also in the [atcConfig.yml](atcConfig.yml) file.<br>
 Refer to the documentation on [ATC config file](https://www.project-piper.io/steps/abapEnvironmentRunATCCheck/#atc-config-file-example) for more information.
 

--- a/atcConfig.yml
+++ b/atcConfig.yml
@@ -1,4 +1,4 @@
-checkvariant: ABAP_CLOUD_DEVELOPMENT_DEFAULT
+checkvariant: ABAP_CLOUD_DEVELOPMENT_PARTNER
 atcobjects:
   softwarecomponent:
     - name: "/NAMESPC/COMPONENTA"


### PR DESCRIPTION
With Steampunk 2505 a new partner default check variant (ABAP_CLOUD_DEVELOPMENT_PARTNER) is available. We aligned to use the new variant in all examples relevant to partners.