### PR TITLE
New partner default check variant ABAP_CLOUD_DEVELOPMENT_PARTNER

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -9,9 +9,7 @@ stages:
   Clone Repositories:
     strategy: 'Pull'
   ATC:
-    # In order to be executed, the ATC stage needs at least one configuration entry
-    # If the ATC stage should not be executed, delete the whole section
-    execute: stage
+    atcConfig: 'atcConfig.yml'
   AUnit:
     # In order to be executed, the AUnit stage needs at least one configuration entry
     # If the AUnit stage should not be executed, delete the whole section

--- a/atcConfig.yml
+++ b/atcConfig.yml
@@ -1,0 +1,4 @@
+checkvariant: ABAP_CLOUD_DEVELOPMENT_PARTNER
+atcobjects:
+  softwarecomponent:
+    - name: "/DMO/SWC"


### PR DESCRIPTION
With Steampunk 2505 a new partner default check variant (ABAP_CLOUD_DEVELOPMENT_PARTNER) is available. We aligned to use the new variant in all examples relevant to partners.