### PR TITLE
New partner default check variant ABAP_CLOUD_DEVELOPMENT_PARTNER

### DIFF
--- a/atcConfig.yml
+++ b/atcConfig.yml
@@ -1,4 +1,4 @@
-checkvariant: ABAP_CLOUD_DEVELOPMENT_DEFAULT
+checkvariant: ABAP_CLOUD_DEVELOPMENT_PARTNER
 atcobjects:
   softwarecomponent:
     - name: "/DMO/SWC"


### PR DESCRIPTION
With Steampunk 2505 a new partner default check variant (ABAP_CLOUD_DEVELOPMENT_PARTNER) is available. We aligned to use the new variant in all examples relevant to partners.